### PR TITLE
Update bit-docs-html-toc and bit-docs-docjs-theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
 
       "bit-docs-prettify": "^0.1.0",
       "bit-docs-html-highlight-line": "^0.2.2",
-      "bit-docs-html-toc": "^0.3.0",
+      "bit-docs-html-toc": "^0.4.0",
       "bit-docs-tag-demo": "^0.3.0",
-      "bit-docs-docjs-theme": "^0.1.0"
+      "bit-docs-docjs-theme": "^0.2.0"
     },
     "glob": {
       "pattern": "{node_modules,docs}/{steal,steal-tools}/**/*.{js,md}",


### PR DESCRIPTION
With these two we should now get anchor heading ids like Github