### PR TITLE
Add steal-css for documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/stealjs/stealjs#readme",
   "dependencies": {
     "steal": "^1.0.0-rc.0",
+    "steal-css": "^1.0.0-rc.0",
     "steal-socket.io": "^4.0.0",
     "steal-tools": "^1.0.0-rc.0"
   },
@@ -44,7 +45,7 @@
       "bit-docs-docjs-theme": "^0.3.3"
     },
     "glob": {
-      "pattern": "{node_modules,docs}/{steal,steal-tools,steal-socket.io}/**/*.{js,md}",
+      "pattern": "{node_modules,docs}/{steal,steal-*}/**/*.{js,md}",
       "ignore": ["node_modules/steal/test/**/*","node_modules/steal-tools/test/**/*"]
     },
     "parent": "StealJS",


### PR DESCRIPTION
This adds the steal-css module, which lives under Steal's ecosystem
section.