### PR TITLE
Clean up the migration guide & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,26 @@ This repository houses the source for the website.
 
 ## Contributing
 
-If you'd like to have your Steal plugin added under the *Ecosystems* section on the website, please add an issue and we can discuss it.
+If you’d like to have your Steal plugin added under the *Ecosystems* section on the website, please add an issue and we can discuss it.
 
 If you want to work on the website, first clone it:
 
 ```
-> git clone https://github.com/stealjs/stealjs.git
+git clone https://github.com/stealjs/stealjs.git
 ```
 
-Then to generate the document run:
+Then install the dependencies:
 
 ```
-> npm run document
+npm install
+```
+
+Then generate the documentation:
+
+```
+npm run document
 ```
 
 ## License
 
-Steal, StealTools, and all subprojects are licensed under [The MIT License](https://github.com/stealjs/steal/blob/master/license.md).
+Steal, StealTools, and all sub-projects are licensed under [the MIT License](https://github.com/stealjs/steal/blob/master/license.md).

--- a/doc/steal-topics/migrating-1.md
+++ b/doc/steal-topics/migrating-1.md
@@ -1,20 +1,29 @@
-@page StealJS.topics.migrating-one Migrating to 1.0
+@page StealJS.topics.migrating-one Migrating to StealJS 1
 @parent StealJS.topics
+@outline 0
 
-This guide walks you through upgrading to StealJS 1.0. It starts with the important breaking changes and then introduces new features you might want to take advantage of and finally goes over the deprecations.
+This guide walks you through upgrading to StealJS 1. It’s broken up into four parts:
 
-Overall most of the changes needed to upgrade from a StealJS 0.16 project to StealJS 1.0 are quite small. If you are using an older version of StealJS and want to migrate to 1.0 please check out the [changelog](StealJS.changelog.html) to see the changes that have occurred since the version you are currently using.
+1. [Getting StealJS 1](#getting-steal-1) for your existing project
+2. [Breaking changes](#breaking-changes) that require updates to your code
+3. [New features](#new-features) you might want to take advantage of
+4. [Deprecations](#deprecations) to consider for the future
 
-## Getting Steal 1.0
+Overall, most of the changes needed to upgrade from a StealJS 0.16 project to StealJS 1 are quite small. If you are using an older version of StealJS and want to migrate to StealJS 1, please check out the [changelog](StealJS.changelog.html) to see the changes that have occurred since the version you are currently using.
 
-The recommended way to get StealJS is using [npm](http://npmjs.org/). If you're not already using StealJS with npm, we recommend doing so. You can install with:
+<a name="getting-steal-10"></a>
+## Getting StealJS 1
+
+The recommended way to get StealJS is using [npm](http://npmjs.org/). If you’re not already using StealJS with npm, we recommend doing so. You can install with:
 
 ```
-> npm install steal --save
-> npm install steal-tools --save-dev
+npm install steal@1 --save
+npm install steal-tools@1 --save-dev
 ```
 
-If you're already using StealJS through npm you can upgrade the version number. In your package.json change the versions of `steal` and `steal-tools` to:
+If you’re already using StealJS through npm, you can run the above commands to upgrade and your `package.json` will be updated.
+
+If you want to upgrade manually, change the versions of `steal` and `steal-tools` in your `package.json` to:
 
 ```
 {
@@ -30,11 +39,12 @@ If you're already using StealJS through npm you can upgrade the version number. 
   }
 }
 ```
+@highlight 5,10
 
-If you are using [Grunt](http://gruntjs.com/) for production builds, the grunt tasks for StealJS have been moved to their own project, [grunt-steal](https://github.com/stealjs/grunt-steal). More on this is explained below, but for now you will want to install grunt-steal:
+If you are using [Grunt](http://gruntjs.com/) for production builds, the Grunt tasks for StealJS have been moved to their own project, [grunt-steal](https://github.com/stealjs/grunt-steal). This is explained in [further detail below](#grunt-tasks), but for now you will want to install `grunt-steal`:
 
 ```
-> npm install grunt-steal --save-dev
+npm install grunt-steal --save-dev
 ```
 
 ## Breaking changes
@@ -43,65 +53,78 @@ The following are breaking changes to the way StealJS works that will require yo
 
 ### Production script tag
 
-If you are using the [npm](./npm.html) plugin (and you should be!) you may need to change the [config.main] attribute in the StealJS script tag for production.  If your script tag currently looks like this:
+If you are using the [npm](./npm.html) plugin (and you should be!), you may need to change the [config.main] attribute in the StealJS script tag for production.  If your script tag currently looks like this:
 
 ```html
 <script src="./node_modules/steal/steal.production.js"
   main="index"></script>
 ```
 
-Where `"index"` is your application's main module you'll want to change that to:
+Where `"index"` is your application’s main module, you’ll want to change that to:
 
 ```html
 <script src="./node_modules/steal/steal.production.js"
   main="app/index"></script>
 ```
+@highlight 2
 
-Where **app** is the `name` in your package.json (your package name). steal-tools now always writes bundles out to include the package name, so where it previously might have written to the file `dist/bundles/index.js` it now writes to `dist/bundles/app/index.js`.
+Where `app` is your package’s `name` in your `package.json`. `steal-tools` now always includes the package name in the bundles it produces, so where it previously might have written to the file `dist/bundles/index.js`, it now writes to `dist/bundles/app/index.js`.
 
-Using the new [configured steal.production](#easier-production-use) alleviates the need to know about this. The [StealJS.moving-to-prod] guide has been updated, and contains all of the ways to use StealJS in production.
+Using the new [configured steal.production](#easier-production-use) alleviates the need to know about this. The [StealJS.moving-to-prod] guide has been updated; it contains all of the ways to use StealJS in production.
 
 ### NPM 3
 
-The [npm] plugin now defaults to compatibility with npm 3 and above. If you're using Node version 5+, you have npm 3.  If you are using an older version of Node, or are using npm 2 for another reason, you need to update your configuration in your package.json to add:
+The [npm] plugin now defaults to compatibility with npm 3 and above. If you’re using Node version 5+, you have npm 3.  If you are using an older version of Node, or are using npm 2 for another reason, you need to update your configuration in your `package.json` to add:
 
 ```json
-"system": {
+"steal": {
   "npmAlgorithm": "nested"
 }
 ```
 
-If you *are* using npm 3+ and have `"npmAlgorithm": "flat"` in your package.json, you can remove this, but leaving it in your config will not cause any harm.
+If you *are* using npm 3+ and have `"npmAlgorithm": "flat"` in your `package.json`, you can remove this, but leaving it in your config will not cause any harm.
 
 ### CSS and Less plugins
 
-The CSS and Less plugins are no longer included with the steal npm package, but rather are contained within their own projects; **steal-css** and **steal-less**. To use them you need to install them and save them as devDependencies:
+The CSS and Less plugins are no longer included with the steal npm package, but rather are contained within their own projects: [steal-css](http://npmjs.com/package/steal-css) and [steal-less](http://npmjs.com/package/steal-less). To use them, install them as `devDependencies`:
 
 ```
-> npm install steal-css steal-less --save-dev
+npm install steal-css steal-less --save-dev
 ```
 
-And then update your package.json to use the new **plugins** configuration which tells Steal to load their package.json for metadata:
+Also update your `package.json` to use the new `plugins` configuration which tells Steal to load their `package.json` for metadata:
 
 ```json
-"system": {
+"steal": {
   ...
   
   "plugins": ["steal-less"]
 }
 ```
 
+### Stache plugin
+
+Similarly, if you’re using CanJS and the [steal-stache](https://www.npmjs.com/package/steal-stache) plugin, you’ll need to add it to the `plugins` configuration in your `package.json`:
+
+```json
+"steal": {
+  ...
+
+  "plugins": ["steal-stache"]
+}
+```
+
 ### Grunt tasks
 
-Likewise, the Grunt tasks are no longer included with steal-tools. This is part of a long-term project of decreasing the size of our core packages; steal-tools being one of them.
+Likewise, the Grunt tasks are no longer included with `steal-tools`. This is part of a long-term project of decreasing the size of our core packages; `steal-tools` being one of them.
 
-Install [grunt-steal] as a devDependency:
+Install [grunt-steal] as a dev-dependency:
 
 ```
-> npm install grunt-steal --save-dev
+npm install grunt-steal --save-dev
 ```
 
-And in your *Gruntfile.js* change:
+In your `Gruntfile.js`, change:
 
 ```js
 grunt.loadNpmTasks("steal-tools");
@@ -113,7 +136,7 @@ to:
 grunt.loadNpmTasks("grunt-steal");
 ```
 
-Finally change the configuration object to be `steal` rather than `system` like so:
+Finally, change the configuration object to be `steal` rather than `system` like so:
 
 ```
 grunt.initConfig({
@@ -131,18 +154,19 @@ grunt.initConfig({
   }
 });
 ```
+@highlight 5
 
 This also applies to the [grunt-steal.export] and [grunt-steal.live-reload] tasks. Learn more in the [grunt-steal] docs.
 
 ### bundlesPath
 
-The use of [config.bundlesPath] in steal-tools is deprecated in favor of the new `dest` option.
+The use of [config.bundlesPath] in `steal-tools` is deprecated in favor of the new `dest` option.
 
-[config.bundlesPath] has always been a bit confusing because it means something different when used in the client (to set the path where production bundles are served) vs. in the build (which previously meant where the bundles are written).
+[config.bundlesPath] has always been confusing because it means something different when used in the client (to set the path where production bundles are served) vs. in the build (which previously meant where the bundles are written).
 
-`dest` clears this confusion up. Setting `dest` tells steal-tools where your production files go. It will write out your bundles inside of this path. 
+`dest` clears this confusion up. Setting `dest` tells `steal-tools` where your production files go. It will write out your bundles inside of this path.
 
-To upgrade change your build script that looks something like this:
+To upgrade, change your build script that looks something like this:
 
 ```js
 stealTools.build({
@@ -161,12 +185,17 @@ stealTools.build({
 });
 ```
 
-steal-tools will write out bundles to `path/to/build/bundles` and also write out a pre-configured StealJS script to `path/to/build/steal.production.js`. More on that [below](#easier-production-use).
+`steal-tools` will write out bundles to `path/to/build/bundles` and also write out a pre-configured StealJS script to `path/to/build/steal.production.js`. More on that [below](#easier-production-use).
 
 
 ### bundlesDepth
 
-`bundlesDepth` has been renamed to `maxBundleRequests` and `mainsDepth` has been renamed to `maxMainRequests`. These renamings are to more accurately reflect what the option's purpose is: to control the number of requests that will be needed in production. The functionality remains the same.
+Two configuration options have been renamed:
+
+- `bundlesDepth` to `maxBundleRequests`
+- `mainsDepth` to `maxMainRequests`
+
+These options have been renamed to more accurately reflect what their purpose is: to control the number of requests that will be needed in production. The functionality remains the same.
 
 Just change this option in your build script:
 
@@ -187,30 +216,31 @@ stealTools.build({
   maxBundleRequests: 3
 }
 ```
+@highlight 4
 
 ## New features
 
-Although StealJS 1.0 is mostly about solidifying that StealJS is production-ready, there are a few new features worth mentioning.
+Although StealJS 1 is mostly about solidifying that StealJS is production-ready, there are a few new features worth mentioning.
 
-### Loading from your project's root
+### Loading from your project’s root
 
-Since the introduction of the npm plugin, there has been an issue with wanting to load code from the project's root, which may not always be a sibling of your project's `node_modules/` folder. In the past this was done by using your project's package name to load: `app/components/tabs` where `app` is the package.json **"name"** field.
+Since the introduction of the npm plugin, there has been an issue with wanting to load code from the project’s root, which may not always be a sibling of your project’s `node_modules/` folder. In the past this was done by using your project’s package name to load: `app/components/tabs` where `app` is the `"name"` field in your `package.json`.
 
-This wasn't ideal because project names could be long, and if your project name changed, these imports would need to be refactored.
+This wasn’t ideal because project names could be long, and if your project name changed, these imports would need to be refactored.
 
-In 1.0, [~] refers to your project's root.
+In StealJS 1, `~` refers to your project’s root.
 
 ```
 import tabs from "~/components/tabs";
 ```
 
-[~] is treated the same as your project's package name in StealJS.
+`~` is treated the same as your project’s package name in StealJS.
 
 ### Easier production use
 
-Using Steal in development is as easy as adding a script tag that points to steal.js inside your `node_modules/` folder, but up to now when changing to production you have to add a few attributes such as the [config.main], and possibly [config.bundlesPath] or even [config.baseURL].
+Using Steal in development is as easy as adding a script tag that points to `steal.js` inside your `node_modules` folder, but up to now when changing to production you have to add a few attributes such as the [config.main], and possibly [config.bundlesPath] or even [config.baseURL].
 
-In 1.0 using Steal in production is just as easy as in development. steal-tools now builds out a pre-configured *steal.production.js* to your dest folder. By default it will be written to `dist/steal.production.js`. So now all you need to do is use this script tag in production:
+Using Steal 1 in production is just as easy as in development. `steal-tools` now builds out a pre-configured `steal.production.js` to your `dest` folder. By default it will be written to `dist/steal.production.js`. So now all you need to do is use this script tag in production:
 
 ```js
 <script src="./dist/steal.production.js"></script>
@@ -218,9 +248,9 @@ In 1.0 using Steal in production is just as easy as in development. steal-tools 
 
 ### Babel 6
 
-1.0 finally brings Babel 6. We are using [greenkeeper](https://greenkeeper.io/) to keep our packages up-to-date so we'll be doing patch releases as new versions of Babel come out.
+StealJS 1 includes [Babel 6](https://babeljs.io/blog/2015/10/29/6.0.0)! We are using [Greenkeeper](https://greenkeeper.io/) to keep our packages up-to-date so there will be patch releases as new versions of [Babel](https://babeljs.io/) come out.
 
-You can configure which presets/plugins are used in your package.json config:
+You can configure which presets/plugins are used in your `package.json` config:
 
 ```json
 "steal": {
@@ -234,11 +264,11 @@ The available presets and plugins are listed in the [config.babelOptions] docs.
 
 ## Deprecations
 
-These things still exist in 1.0 but are considered deprecated and might be removed in 2.0.
+These things still exist in StealJS 1 but are considered deprecated and might be removed in 2.0.
 
 ### system name replaced by steal
 
-In 0.16 StealJS used a special property which we called *system* to configure StealJS. You have probably used this in your package.json like:
+In 0.16, StealJS used a special property called `system` to configure StealJS. You have probably used this in your `package.json` like:
 
 ```json
 "system": {
@@ -248,7 +278,7 @@ In 0.16 StealJS used a special property which we called *system* to configure St
 }
 ```
 
-In 1.0 this option has changed to be called *steal*, so the above would become:
+In StealJS 1, this option is now called `steal`, so the above would become:
 
 ```json
 "steal": {
@@ -257,8 +287,9 @@ In 1.0 this option has changed to be called *steal*, so the above would become:
   }
 }
 ```
+@highlight 1
 
-Similarly, to dynamically import code we've previously taught to use System.import. This should be replaced by using [steal.import] instead:
+Similarly, to dynamically import code we’ve previously taught to use `System.import`. This should be replaced by using [steal.import] instead:
 
 ```js
 steal.import("my/app").then(function(){
@@ -266,13 +297,13 @@ steal.import("my/app").then(function(){
 });
 ```
 
-StealJS was built on top of a specification for modules that was planned to be part of ES6, but never came to pass. System.import() is supported by StealJS, SystemJS, and WebPack, but will never appear in the browser natively, so we are moving away from the *System* name so that in the future we can support the browser's native module system, `<script type="module">`.
+StealJS was built on top of a specification for modules that was planned to be part of ES6, but never came to pass. `System.import()` is supported by StealJS, SystemJS, and WebPack, but will never appear in the browser natively, so we are moving away from the `System` name so that in the future we can support the browser’s native module system, `<script type="module">`.
 
-The global `System` is still available and won't be removed any time soon, but you should use *steal* in its place, or `steal.loader` if you really do need the loader.
+The global `System` is still available and won’t be removed any time soon, but you should use `steal` in its place, or `steal.loader` if you really do need the loader.
 
 ### Configuring the loader directly
 
-In the past you've been able to configure the the System object directly to add [config.map], [config.ext] and other configuration values. In 1.0 this is deprecated in favor of using [config.config steal.config()]:
+In the past you’ve been able to configure the System object directly to add [config.map], [config.ext], and other configuration values. In Steal 1, this is deprecated in favor of using [config.config steal.config()]:
 
 ```js
 steal.config({

--- a/doc/steal-topics/migrating-1.md
+++ b/doc/steal-topics/migrating-1.md
@@ -1,4 +1,4 @@
-@page StealJS.topics.migrating-one Migrating to StealJS 1
+@page StealJS.topics.migrating-one Migrating to StealJS 1.X
 @parent StealJS.topics
 @outline 0
 

--- a/doc/steal-topics/migrating-1.md
+++ b/doc/steal-topics/migrating-1.md
@@ -84,33 +84,32 @@ The [npm] plugin now defaults to compatibility with npm 3 and above. If you’re
 
 If you *are* using npm 3+ and have `"npmAlgorithm": "flat"` in your `package.json`, you can remove this, but leaving it in your config will not cause any harm.
 
-### CSS and Less plugins
+<a name="css-and-less-plugins"></a>
+### Plugins configuration
 
-The CSS and Less plugins are no longer included with the steal npm package, but rather are contained within their own projects: [steal-css](http://npmjs.com/package/steal-css) and [steal-less](http://npmjs.com/package/steal-less). To use them, install them as `devDependencies`:
+The following plugins are no longer included with the `steal` npm package, but rather are contained within their own projects:
+
+- [steal-css](https://www.npmjs.com/package/steal-css)
+- [steal-less](https://www.npmjs.com/package/steal-less)
+- [steal-stache](https://www.npmjs.com/package/steal-stache)
+
+To use them, install them as `devDependencies` and use the new `plugins` configuration to tell Steal to load their `package.json` for metadata.
+
+For example, to use `steal-less`, install it with npm:
 
 ```
-npm install steal-css steal-less --save-dev
+npm install steal-less --save-dev
 ```
 
-Also update your `package.json` to use the new `plugins` configuration which tells Steal to load their `package.json` for metadata:
+Then update the `plugins` configuration in your `package.json`:
 
 ```json
-"steal": {
+{
   ...
-  
-  "plugins": ["steal-less"]
-}
-```
-
-### Stache plugin
-
-Similarly, if you’re using CanJS and the [steal-stache](https://www.npmjs.com/package/steal-stache) plugin, you’ll need to add it to the `plugins` configuration in your `package.json`:
-
-```json
-"steal": {
-  ...
-
-  "plugins": ["steal-stache"]
+  "steal": {
+    ...
+    "plugins": ["steal-less"]
+  }
 }
 ```
 


### PR DESCRIPTION
- Use `steal` instead of `system` in most of the examples
- Include a more useful outline at the beginning of the migration guide
- Highlight some of the code to make the changes stand out
- Add a section about `steal-stache`
- Use just “1” instead of “1.0” so that the docs don’t look outdated if/when there is a 1.1
- Include `@1` in the npm commands so existing users can run those same commands to upgrade
- Instruct the user in the README to install the dependencies
- Remove the `> ` in front of commands so they’re easier to copy & paste
- Various spelling/grammar/punctuation fixes

Fixes #23