### PR TITLE
Rename bit-docs npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "StealJS's website",
   "main": "index.js",
   "scripts": {
-    "document": "bit-docs -fd",
-    "doc": "bit-docs",
+    "document": "bit-docs",
+    "document:force": "bit-docs -fd",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Always get confused about which one uses the force flag, also, we use the same names in DoneJS 