### PR TITLE
Add `rm -rf node_modules` to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 publish-docs:
+	rm -rf node_modules
 	npm install
 	git checkout -b gh-pages
 	./node_modules/.bin/bit-docs -fd


### PR DESCRIPTION
After I fixed https://github.com/stealjs/stealjs/issues/48, I discovered that someone else published the website but hadn’t cleared their `node_modules` folder, so we had another month of inaccurate stats. 😢