### PR TITLE
Update bit-docs-generate-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       "bit-docs-js": "^0.0.6",
       "bit-docs-tag-sourceref": "^0.0.3",
       "bit-docs-tag-package": "^0.0.3",
-      "bit-docs-generate-html": "^0.4.3",
+      "bit-docs-generate-html": "^0.7.1",
       "bit-docs-prettify": "^0.1.0",
       "bit-docs-html-highlight-line": "^0.2.2",
       "bit-docs-html-toc": "^0.4.0",


### PR DESCRIPTION
0.7.1 includes the fix for the script tag breaking the BuildOptions page.