### PR TITLE
Use pre-releases of bit-docs plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,20 +34,20 @@
     "steal-tools": "^1.8.0"
   },
   "devDependencies": {
-    "bit-docs": "0.0.8-0"
+    "bit-docs": "pre"
   },
   "bit-docs": {
     "dependencies": {
-      "bit-docs-glob-finder": "^0.0.5",
-      "bit-docs-dev": "^0.0.3",
-      "bit-docs-js": "^0.0.6",
-      "bit-docs-tag-sourceref": "^0.0.3",
-      "bit-docs-tag-package": "^0.0.3",
-      "bit-docs-generate-html": "^0.7.1",
-      "bit-docs-prettify": "^0.1.0",
-      "bit-docs-html-highlight-line": "^0.2.2",
-      "bit-docs-html-toc": "^0.4.0",
-      "bit-docs-tag-demo": "^0.3.0",
+      "bit-docs-glob-finder": "pre",
+      "bit-docs-dev": "pre",
+      "bit-docs-js": "pre",
+      "bit-docs-tag-sourceref": "pre",
+      "bit-docs-tag-package": "pre",
+      "bit-docs-generate-html": "pre",
+      "bit-docs-prettify": "pre",
+      "bit-docs-html-highlight-line": "pre",
+      "bit-docs-html-toc": "pre",
+      "bit-docs-tag-demo": "pre",
       "bit-docs-stealjs-theme": "^0.7.0"
     },
     "glob": {


### PR DESCRIPTION
Looks like the StealJS website still works using the bleeding edge of bit-docs plugins.

Watch it build without errors here: https://asciinema.org/a/i6it2vcH6OJSalhP8wAvJ8qwZ

Don't merge this until pre versions have been updated to actual version ranges (after all current pre-release bit-docs plugins are fully released).