### PR TITLE
Add documentation on error messages

### DIFF
--- a/doc/steal-topics/development/error-messages.md
+++ b/doc/steal-topics/development/error-messages.md
@@ -1,0 +1,17 @@
+@page StealJS.error-messages Error Messages
+@parent StealJS.development 9
+@body
+
+The following are common __error messages__ that occur within StealJS apps. This guide lists some of the most common types of error messages and provides some advise on how to track down where the problem is in your code.
+
+## 404 Not Found
+
+This error occurs where requesting a module fails because the web server returned a __404__ status code.
+
+<img width="641" alt="404 error" src="https://user-images.githubusercontent.com/361671/36808550-6b835694-1c93-11e8-8420-16789dde804e.png">
+
+The cause of this error could be:
+
+* The file hasn't been created (or saved) yet.
+* There is a typo in the import statement. Click the link in the stack trace (__app.js:6__ in the above screenshot) to take you to the code in the debugger to see.
+* If the module being imported is from a 3rd party dependency, you might have forgotten to save the dependency in your package.json's `dependencies` list.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/stealjs/stealjs#readme",
   "dependencies": {
     "grunt-steal": "^1.0.0",
-    "steal": "^1.5.18",
+    "steal": "^1.7.0",
     "steal-bundle-manifest": "^1.0.4",
     "steal-conditional": "^0.4.0",
     "steal-css": "^1.2.3",


### PR DESCRIPTION
This goes along with https://github.com/stealjs/steal/pull/1341, adds a
page to document common error messages and documents the 404 error.