### PR TITLE
Fix matching pattern so steal-conditional guides are included

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
       "bit-docs-stealjs-theme": "^0.8.1"
     },
     "glob": {
-      "pattern": "{node_modules,doc}/{steal,grunt-steal,steal-*}/{,lib,doc/types,doc,!(node_modules)}/*.{js,md}",
+      "pattern": "{node_modules,doc}/{steal,grunt-steal,steal-*}/{,lib,docs/**,doc/types,doc,!(node_modules)}/*.{js,md}",
       "ignore": [
         "node_modules/steal/test/**/*",
         "node_modules/steal-tools/test/**/*",


### PR DESCRIPTION
Closes stealjs/steal#1464

It was not matching the docs folder where steal-conditionals keeps its markdown files:

![screen shot 2019-01-11 at 4 01 10 pm](https://user-images.githubusercontent.com/724877/51063897-43f8f400-15ba-11e9-88b1-0fdfc609bf9b.png)

with the pattern change:
![screen shot 2019-01-11 at 4 01 23 pm](https://user-images.githubusercontent.com/724877/51063937-6be85780-15ba-11e9-8eea-6c1cdc72954b.png)

The generated page looks good.
![screen shot 2019-01-11 at 4 01 37 pm](https://user-images.githubusercontent.com/724877/51063998-b4077a00-15ba-11e9-8d09-474d4af8b648.png)

